### PR TITLE
remove figaro gem because use GCP to deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@
 
 .byebug_history
 
-# Ignore application configuration
-/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
-# 存放隱密資料(key)，會新增application.yml檔存放資料並加到gitignore內
-gem 'figaro', '~> 1.1', '>= 1.1.1'
 # user login
 gem 'devise'
 # 檢查代碼風格

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,6 @@ GEM
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.25)
-    figaro (1.1.1)
-      thor (~> 0.14)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (1.1.0)
@@ -208,7 +206,6 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   devise
-  figaro (~> 1.1, >= 1.1.1)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.7)


### PR DESCRIPTION
-做了什麼東西或什麼改變?
移除figaro gem
-為什麼要做這些改變?(如果是一開始功能就不用回答)
用GCP部屬直接把一些不能公開的資料放在secret.yml就可以
-有什麼要特別注意的地方嗎?(像是加在gitignore的檔案有做什麼變動之類的)
-有什麼要說的?
不能公開的資料如果可以統一放在secret.yml內統一管理 